### PR TITLE
nanobsd: Fix prune_usr()

### DIFF
--- a/tools/tools/nanobsd/defaults.sh
+++ b/tools/tools/nanobsd/defaults.sh
@@ -1301,7 +1301,7 @@ prune_usr() {
 	    while read -r d; do
 		rmdir "$d" > /dev/null 2>&1 || true
 		if [ -n "$NANO_METALOG" ]; then
-			sed -i "" -e "\|^\.${d#"$NANO_WORLDDIR"}|d" "$NANO_METALOG"
+			sed -i "" -e "\|^\.${d#"$NANO_WORLDDIR"} |d" "$NANO_METALOG"
 		fi
 	done
 }


### PR DESCRIPTION
In a recent refactoring, a sed searching pattern was introduced to remove matching entries from the mtree.

The issue is that when a directory like:

/usr/include/machine/pc

is empty, it is used in the sed pattern for removing entries in the METALOG, but it will also match entries like:

./usr/include/machine/pcb.h
./usr/include/machine/pci_cfgreg.h
./usr/include/machine/pcpu.h
./usr/include/machine/pcpu_aux.h

Fix it by adding a "missing space" at the end of the pattern, to mimic the mtree entry.

Note that tgt_rm() has a similar pattern, but in that case, we do want to match everything.