### PR TITLE
nanobsd: Update pkgbase customizations

### DIFF
--- a/tools/tools/nanobsd/defaults.sh
+++ b/tools/tools/nanobsd/defaults.sh
@@ -1493,6 +1493,11 @@ cust_comconsole() {
 
 	# Tell loader to use serial console early.
 	echo "${NANO_BOOT2CFG}" > ${NANO_WORLDDIR}/boot.config
+
+	if $do_precompiled && [ -z "$NANO_NOPKGBASE" ]; then
+		tgt_pkg_update_file_sha256 etc/ttys
+		tgt_pkg_update_config_files_content etc/ttys
+	fi
 }
 
 #######################################################################
@@ -1501,6 +1506,11 @@ cust_comconsole() {
 cust_allow_ssh_root() {
 	sed -i "" -E 's/^#?PermitRootLogin.*/PermitRootLogin yes/' \
 	    ${NANO_WORLDDIR}/etc/ssh/sshd_config
+
+	if $do_precompiled && [ -z "$NANO_NOPKGBASE" ]; then
+		tgt_pkg_update_file_sha256 etc/ssh/sshd_config
+		tgt_pkg_update_config_files_content etc/ssh/sshd_config
+	fi
 }
 
 #######################################################################


### PR DESCRIPTION
Update the contents of the modified NanoBSD customizations in the database (cust_allow_ssh_root and cust_comconsole) by updating the sha256 and content values of the /etc/ssh/sshd and /etc/ttys files in the pkg database.